### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <p align="center"><img height="100" src="https://raw.githubusercontent.com/tauri-apps/wry/refs/heads/dev/.github/splash.png" alt="WRY Webview Rendering library" /></p>
 
+## Repository archived
+
+This repository is archived and no longer maintained. The NOVONOTES-maintained implementation has moved to [`novonotes/wxp`](https://github.com/novonotes/wxp).
+
 [![](https://img.shields.io/crates/v/wry?style=flat-square)](https://crates.io/crates/wry) [![](https://img.shields.io/docsrs/wry?style=flat-square)](https://docs.rs/wry/)
 [![License](https://img.shields.io/badge/License-MIT%20or%20Apache%202-green.svg)](https://opencollective.com/tauri)
 [![Chat Server](https://img.shields.io/badge/chat-discord-7289da.svg)](https://discord.gg/SpmNs4S)


### PR DESCRIPTION
## Summary
- Add a README notice that this repository is archived and no longer maintained.
- Point users to the NOVONOTES-maintained `novonotes/wxp` repository.

## Testing
- Not run; documentation-only change.